### PR TITLE
Generate random constants using a simple LCG instead of ChaCha20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,5 @@ edition = "2018"
 [dependencies]
 bimap = "0.4.0"
 itertools = "0.8.0"
-num = { version = "0.2.0", features = ["rand"] }
+num = "0.2.0"
 num-traits = "0.2.8"
-rand = "0.5"
-rand_chacha = "0.1.1"

--- a/src/field.rs
+++ b/src/field.rs
@@ -7,11 +7,9 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Shl, Sub, Su
 use std::str::FromStr;
 
 use num::bigint::ParseBigIntError;
-use num::bigint::RandBigInt;
 use num::BigUint;
 use num_traits::One;
 use num_traits::Zero;
-use rand::Rng;
 
 /// A prime order field.
 pub trait Field: 'static {
@@ -135,18 +133,6 @@ impl<F: Field> Element<F> {
     /// significant bit of x. Return false for outside of range.
     pub fn bit(&self, i: usize) -> bool {
         ((self.to_biguint() >> i) & BigUint::one()).is_one()
-    }
-
-    /// Return a random field element, uniformly distributed in [0, size()).
-    /// This is the fastest implementation since max_bits() is always GSB bounded.
-    pub fn random(rng: &mut impl Rng) -> Self {
-        let bits = Self::max_bits();
-        loop {
-            let r = rng.gen_biguint(bits);
-            if r < F::order() {
-                return Self::from(r);
-            }
-        }
     }
 }
 

--- a/src/lcg.rs
+++ b/src/lcg.rs
@@ -17,7 +17,7 @@ impl LCG {
     }
 
     pub fn next_u32(&mut self) -> u32 {
-        self.state = self.state * 1664525 + 1013904223;
+        self.state = self.state.wrapping_mul(1664525).wrapping_add(1013904223);
         self.state
     }
 
@@ -48,5 +48,19 @@ impl LCG {
             chunk_data.push(self.next_u32() % (1 << remaining_bits))
         }
         BigUint::new(chunk_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lcg::LCG;
+
+    #[test]
+    fn next_u32() {
+        let mut lcg = LCG::new();
+        assert_eq!(lcg.next_u32(), 1013904223);
+        assert_eq!(lcg.next_u32(), 1196435762);
+        assert_eq!(lcg.next_u32(), 3519870697);
+        assert_eq!(lcg.next_u32(), 2868466484);
     }
 }

--- a/src/lcg.rs
+++ b/src/lcg.rs
@@ -1,0 +1,52 @@
+/// This module provides a linear congruential generator for (not cryptographically secure) random
+/// data.
+
+use num::BigUint;
+use num_traits::One;
+
+use crate::field::{Element, Field};
+
+/// A simple linear congruential generator, with parameters taken from Numerical Recipes.
+pub struct LCG {
+    state: u32
+}
+
+impl LCG {
+    pub fn new() -> Self {
+        LCG { state: 0 }
+    }
+
+    pub fn next_u32(&mut self) -> u32 {
+        self.state = self.state * 1664525 + 1013904223;
+        self.state
+    }
+
+    pub fn next_element<F: Field>(&mut self) -> Element<F> {
+        Element::from(self.next_biguint(F::order()))
+    }
+
+    pub fn next_biguint(&mut self, limit_exclusive: BigUint) -> BigUint {
+        let bits = (&limit_exclusive - BigUint::one()).bits();
+        loop {
+            let n = self.next_biguint_bits(bits);
+            if n < limit_exclusive {
+                return n;
+            }
+        }
+    }
+
+    fn next_biguint_bits(&mut self, bits: usize) -> BigUint {
+        let full_chunks = bits / 32;
+        let remaining_bits = bits % 32;
+        let partial_chunk = remaining_bits > 0;
+
+        let mut chunk_data = Vec::new();
+        for _i in 0..full_chunks {
+            chunk_data.push(self.next_u32());
+        }
+        if partial_chunk {
+            chunk_data.push(self.next_u32() % (1 << remaining_bits))
+        }
+        BigUint::new(chunk_data)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ mod field_arithmetic;
 mod gadget;
 mod gadget_builder;
 mod gadget_traits;
+mod lcg;
 mod matrices;
 mod merkle_damgard;
 mod merkle_trees;

--- a/src/merkle_damgard.rs
+++ b/src/merkle_damgard.rs
@@ -1,12 +1,10 @@
-//! This module extends GadgetBuilder with an implementation of the Merkle-Damgard construction.
-
-use rand::SeedableRng;
-use rand_chacha::ChaChaRng;
+//! This module extends GadgetBuilder with an implementation of the Merkle-Damgård construction.
 
 use crate::{CompressionFunction, HashFunction};
 use crate::expression::Expression;
 use crate::field::{Element, Field};
 use crate::gadget_builder::GadgetBuilder;
+use crate::lcg::LCG;
 
 /// A hash function based on the Merkle–Damgård construction.
 pub struct MerkleDamgard<F: Field, CF: CompressionFunction<F>> {
@@ -21,11 +19,10 @@ impl<F: Field, CF: CompressionFunction<F>> MerkleDamgard<F, CF> {
         MerkleDamgard { initial_value, compress }
     }
 
-    /// Creates a Merkle–Damgård hash function from the given one-way compression function. Uses
-    /// ChaCha20 (seeded with 0) as a source of randomness for the initial value.
+    /// Creates a Merkle–Damgård hash function from the given one-way compression function. Uses a
+    /// simple LCG (seeded with 0) as a source of randomness for the initial value.
     pub fn new_defaults(compress: CF) -> Self {
-        let mut rng = ChaChaRng::seed_from_u64(0);
-        let initial_value = Element::random(&mut rng);
+        let initial_value = LCG::new().next_element();
         Self::new(initial_value, compress)
     }
 }

--- a/src/mimc.rs
+++ b/src/mimc.rs
@@ -1,12 +1,10 @@
 //! This module extends GadgetBuilder with an implementation of MiMC.
 
-use rand::SeedableRng;
-use rand_chacha::ChaChaRng;
-
 use crate::expression::Expression;
 use crate::field::{Element, Field};
 use crate::gadget_builder::GadgetBuilder;
 use crate::gadget_traits::{BlockCipher, Permutation};
+use crate::lcg::LCG;
 use crate::MonomialPermutation;
 
 /// The MiMC block cipher.
@@ -29,13 +27,13 @@ impl<F: Field> MiMCBlockCipher<F> {
 }
 
 impl<F: Field> Default for MiMCBlockCipher<F> {
-    /// Configures MiMC with the number of rounds recommended in the paper. Uses ChaCha20 (seeded
-    /// with 0) as the source of randomness for these constants.
+    /// Configures MiMC with the number of rounds recommended in the paper. Uses a simple LCG
+    /// (seeded with 0) as the source of randomness for these constants.
     fn default() -> Self {
-        let mut rng = ChaChaRng::seed_from_u64(0);
         let mut round_constants = Vec::new();
+        let mut lcg = LCG::new();
         for _r in 0..mimc_recommended_rounds::<F>() {
-            round_constants.push(Element::random(&mut rng));
+            round_constants.push(lcg.next_element());
         }
         MiMCBlockCipher::new(&round_constants)
     }


### PR DESCRIPTION
This lets us drop the `rand` dependency, making the library more lightweiight, and enabling a WebAssembly target in the future.

If there was concern about the low quality of the random constants, we could switch to a custom ChaCha implementation, which is still fairly easy to implement and test. This should be revisited before production use.